### PR TITLE
enables yaml generation to drop keys with blank values

### DIFF
--- a/lib/translation_io/config.rb
+++ b/lib/translation_io/config.rb
@@ -14,6 +14,7 @@ module TranslationIO
     attr_accessor :ignored_key_prefixes
     attr_accessor :localization_key_prefixes
     attr_accessor :yaml_line_width
+    attr_accessor :yaml_remove_empty_keys
 
     attr_accessor :disable_gettext
 
@@ -74,6 +75,8 @@ module TranslationIO
       # Can be nil (default behaviour of Ruby version), -1 (no wrapping) or positive integer (wrapping)
       # Cf. https://github.com/translation/rails/issues/19
       self.yaml_line_width = nil
+
+      self.yaml_remove_empty_keys = false
 
       #######
       # GetText options

--- a/lib/translation_io/flat_hash.rb
+++ b/lib/translation_io/flat_hash.rb
@@ -10,9 +10,7 @@ module TranslationIO
       def to_hash(flat_hash, remove_empty_keys = false)
         hash = {}
 
-        if remove_empty_keys
-          flat_hash = flat_hash.reject { |k, v| v.nil? && !k.end_with?(']') }
-        end
+        flat_hash = flat_hash.reject { |k, v| v.blank? && !k.end_with?(']') } if remove_empty_keys
 
         flat_hash.each_pair do |key, value|
           build_hash_with_flat(hash, key, value)

--- a/lib/translation_io/yaml_conversion.rb
+++ b/lib/translation_io/yaml_conversion.rb
@@ -36,7 +36,8 @@ module TranslationIO
       end
 
       def get_yaml_data_from_flat_translations(flat_translations)
-        translations = FlatHash.to_hash(flat_translations)
+        remove_empty_keys = TranslationIO.config.yaml_remove_empty_keys
+        translations = FlatHash.to_hash(flat_translations, remove_empty_keys)
 
         if TranslationIO.config.yaml_line_width
           data = translations.to_yaml(:line_width => TranslationIO.config.yaml_line_width)

--- a/spec/translation/flat_hash_spec.rb
+++ b/spec/translation/flat_hash_spec.rb
@@ -648,7 +648,6 @@ describe TranslationIO::FlatHash do
     hash.should == {
       'services' => {
         'renting' => "Renting is great!",
-        'blah'    => '',
         'array'   => [
           'first_item',
           '',

--- a/spec/translation/yaml_conversion_spec.rb
+++ b/spec/translation/yaml_conversion_spec.rb
@@ -142,6 +142,30 @@ EOS
       ((result == expected_result_1) || (result == expected_result_2)).should be true
     end
 
+    it 'drops empty keys' do
+      TranslationIO.config.yaml_remove_empty_keys = true
+
+      flat_data = {
+        "en.hello"           => "Hello world",
+        "en.main.menu.stuff" => "This is stuff",
+        "en.bye"             => "Good bye world",
+        "en.empty"           => " "
+      }
+
+      result = subject.get_yaml_data_from_flat_translations(flat_data)
+
+      expected_result = <<-EOS
+---
+en:
+  hello: Hello world
+  main:
+    menu:
+      stuff: This is stuff
+  bye: Good bye world
+EOS
+      result.should eql(expected_result)
+    end
+
     it 'works with weird not-escaped code' do
       flat_data = {
         "en.architects.seo.image" => "<%= AController::Base.h.path('a/b.png') %>",


### PR DESCRIPTION
I've seen that there was a partial solution to dropping keys with blank values but no way to use this via configuration. So I added one. 

Also, since it's named `remove_empty_keys` I've changed the behavior so that keys with blank / empty values get removed instead of only focussing on `nil` values.

default behavior falls back to the way it was