### PR TITLE
Update Ruby and JRuby versions in GitHub Actions test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
           - '3.2'
           - '3.3'
           - 'jruby-9.1.17.0'
+          - 'jruby-9.2'
         gemfile:
           - lowest
           - latest
@@ -31,6 +32,8 @@ jobs:
           - ruby: '3.1'
             gemfile: lowest
           - ruby: '3.2'
+            gemfile: lowest
+          - ruby: '3.3'
             gemfile: lowest
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,8 +18,10 @@ jobs:
           - '3.1'
           - '3.2'
           - '3.3'
+          - '3.4.0-preview1'
           - 'jruby-9.1.17.0'
           - 'jruby-9.2'
+          - 'jruby-9.3'
         gemfile:
           - lowest
           - latest
@@ -34,6 +36,8 @@ jobs:
           - ruby: '3.2'
             gemfile: lowest
           - ruby: '3.3'
+            gemfile: lowest
+          - ruby: '3.4.0-preview1'
             gemfile: lowest
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,8 +32,6 @@ jobs:
             gemfile: lowest
           - ruby: '3.2'
             gemfile: lowest
-          - ruby: '3.3'
-            gemfile: lowest
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
       CC_TEST_REPORTER_ID: 945dfb58a832d233a3caeb84e3e6d3be212e8c7abcb48117fce63b9adcb43647

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
           - '3.0'
           - '3.1'
           - '3.2'
-          - '3.3.0-preview1'
+          - '3.3'
           - 'jruby-9.1.17.0'
         gemfile:
           - lowest
@@ -32,7 +32,7 @@ jobs:
             gemfile: lowest
           - ruby: '3.2'
             gemfile: lowest
-          - ruby: '3.3.0-preview1'
+          - ruby: '3.3'
             gemfile: lowest
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile


### PR DESCRIPTION
We now test for newer versions of Ruby and JRuby :

* **Ruby** (only latest dependencies)
  - 3.3 (instead of 3.3.0-preview1)
  - 3.4.0-preview1 
* **JRuby** (both lowest and latest dependencies)
  - jruby-9.2
  - jruby-9.3